### PR TITLE
Refactorizar pks en rutas

### DIFF
--- a/backend/pawtel/hotel_owners/services.py
+++ b/backend/pawtel/hotel_owners/services.py
@@ -25,18 +25,22 @@ class HotelOwnerService:
     # Common -----------------------------------------------------------------
 
     @staticmethod
-    def authorize_action_hotel_owner(request, pk):
-        target_hotel_owner = HotelOwnerService.retrieve_hotel_owner(pk)
-        if not target_hotel_owner:
-            raise NotFound("Hotel owner does not exist.")
-        target_app_user = AppUserService.retrieve_app_user(target_hotel_owner.user_id)
+    def authorize_action_hotel_owner(request, pk=None):
         logged_in_hotel_owner = HotelOwnerService.get_current_hotel_owner(request)
 
-        if (not target_app_user) or (not target_app_user.is_active):
-            raise NotFound("Hotel owner does not exist.")
+        if pk:
+            target_hotel_owner = HotelOwnerService.retrieve_hotel_owner(pk)
+            if not target_hotel_owner:
+                raise NotFound("Hotel owner does not exist.")
+            target_app_user = AppUserService.retrieve_app_user(
+                target_hotel_owner.user_id
+            )
 
-        if target_hotel_owner.id != logged_in_hotel_owner.id:
-            raise PermissionDenied("Permission denied.")
+            if (not target_app_user) or (not target_app_user.is_active):
+                raise NotFound("Hotel owner does not exist.")
+
+            if target_hotel_owner.id != logged_in_hotel_owner.id:
+                raise PermissionDenied("Permission denied.")
 
     @staticmethod
     def serialize_output_hotel_owner(hotel_owner, many=False):

--- a/backend/pawtel/hotel_owners/tests/test_views.py
+++ b/backend/pawtel/hotel_owners/tests/test_views.py
@@ -58,26 +58,32 @@ class HotelOwnerViewSetTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreaterEqual(len(response.data), 1)
 
-    def test_get_all_hotels_of_hotel_owner(self):
+    def test_get_all_hotels_of_hotel_owner_explicit(self):
         url = reverse(
-            "hotel-owner-get_all_hotels_of_hotel_owner",
+            "hotel-owner-get_all_hotels_of_hotel_owner_explicit",
             kwargs={"pk": self.authenticated_hotel_owner.id},
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
 
-    def test_get_all_hotels_of_inactive_hotel_owner(self):
+    def test_get_all_hotels_of_inactive_hotel_owner_explicit(self):
         url = reverse(
-            "hotel-owner-get_all_hotels_of_hotel_owner",
+            "hotel-owner-get_all_hotels_of_hotel_owner_explicit",
             kwargs={"pk": self.inactive_hotel_owner.id},
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_delete_all_hotels_of_hotel_owner(self):
+    def test_get_all_hotels_of_hotel_owner_implicit(self):
+        url = reverse("hotel-owner-get_all_hotels_of_hotel_owner_implicit")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_delete_all_hotels_of_hotel_owner_explicit(self):
         url = reverse(
-            "hotel-owner-delete_all_hotels_of_hotel_owner",
+            "hotel-owner-delete_all_hotels_of_hotel_owner_explicit",
             kwargs={"pk": self.authenticated_hotel_owner.id},
         )
         response = self.client.delete(url)
@@ -86,13 +92,21 @@ class HotelOwnerViewSetTest(TestCase):
             Hotel.objects.filter(hotel_owner=self.authenticated_hotel_owner).exists()
         )
 
-    def test_delete_all_hotels_of_inactive_hotel_owner(self):
+    def test_delete_all_hotels_of_inactive_hotel_owner_explicit(self):
         url = reverse(
-            "hotel-owner-delete_all_hotels_of_hotel_owner",
+            "hotel-owner-delete_all_hotels_of_hotel_owner_explicit",
             kwargs={"pk": self.inactive_hotel_owner.id},
         )
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_all_hotels_of_hotel_owner_implicit(self):
+        url = reverse("hotel-owner-delete_all_hotels_of_hotel_owner_implicit")
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(
+            Hotel.objects.filter(hotel_owner=self.authenticated_hotel_owner).exists()
+        )
 
     def test_update_hotel_owner(self):
         url = reverse(

--- a/backend/pawtel/hotel_owners/views.py
+++ b/backend/pawtel/hotel_owners/views.py
@@ -13,6 +13,8 @@ class HotelOwnerViewSet(viewsets.ModelViewSet):
     queryset = HotelOwner.objects.all()
     serializer_class = HotelOwnerSerializer
 
+    # Default CRUD -----------------------------------------------------------
+
     def list(self, request):
         hotel_owners = HotelOwnerService.list_hotel_owners()
         output_serializer_data = HotelOwnerService.serialize_output_hotel_owner(
@@ -52,28 +54,70 @@ class HotelOwnerViewSet(viewsets.ModelViewSet):
         AppUserService.general_delete_app_user(request, app_user_id)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    # Get all hotels of hotel owner ------------------------------------------
+
     @action(
         detail=True,
         methods=["get"],
         url_path="hotels",
-        url_name="get_all_hotels_of_hotel_owner",
+        url_name="get_all_hotels_of_hotel_owner_explicit",
     )
-    def get_all_hotels_of_hotel_owner(self, request, pk=None):
+    def get_all_hotels_of_hotel_owner_explicit(self, request, pk=None):
+        # Same as get_all_hotels_of_hotel_owner_implicit, but explicitly recieving the PK in the route (kept for admin)
         HotelOwnerService.authorize_action_hotel_owner(request, pk)
+        return HotelOwnerViewSet.__get_all_hotels_of_hotel_owner_base(pk)
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="my-hotels",
+        url_name="get_all_hotels_of_hotel_owner_implicit",
+    )
+    def get_all_hotels_of_hotel_owner_implicit(self, request):
+        # Same as get_all_hotels_of_hotel_owner_explicit, but implicitly recieving the PK via the authorized user (prefered)
+        HotelOwnerService.authorize_action_hotel_owner(request, pk=None)
+        hotel_owner_id = HotelOwnerService.get_current_hotel_owner(request).id
+        return HotelOwnerViewSet.__get_all_hotels_of_hotel_owner_base(hotel_owner_id)
+
+    @staticmethod
+    def __get_all_hotels_of_hotel_owner_base(pk):
+        # Common logic between both methods
         hotels = HotelOwnerService.get_all_hotels_of_hotel_owner(pk)
         serializer = HotelSerializer(hotels, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    # Delete all hotels of hotel owner ---------------------------------------
 
     @action(
         detail=True,
         methods=["delete"],
         url_path="hotels/delete",
-        url_name="delete_all_hotels_of_hotel_owner",
+        url_name="delete_all_hotels_of_hotel_owner_explicit",
     )
-    def delete_all_hotels_of_hotel_owner(self, request, pk=None):
+    # Same as get_all_hotels_of_hotel_owner_implicit, but explicitly recieving the PK in the route (kept for admin)
+    def delete_all_hotels_of_hotel_owner_explicit(self, request, pk=None):
         HotelOwnerService.authorize_action_hotel_owner(request, pk)
+        return HotelOwnerViewSet.__delete_all_hotels_of_hotel_owner_base(pk)
+
+    @action(
+        detail=False,
+        methods=["delete"],
+        url_path="my-hotels/delete",  # must add final /
+        url_name="delete_all_hotels_of_hotel_owner_implicit",
+    )
+    def delete_all_hotels_of_hotel_owner_implicit(self, request, pk=None):
+        # Same as delete_all_hotels_of_hotel_owner_explicit, but implicitly recieving the PK via the authorized user (prefered)
+        HotelOwnerService.authorize_action_hotel_owner(request, pk)
+        hotel_owner_id = HotelOwnerService.get_current_hotel_owner(request).id
+        return HotelOwnerViewSet.__delete_all_hotels_of_hotel_owner_base(hotel_owner_id)
+
+    @staticmethod
+    def __delete_all_hotels_of_hotel_owner_base(pk=None):
+        # Common logic between both methods
         HotelOwnerService.delete_all_hotels_of_hotel_owner(pk)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    # Others -----------------------------------------------------------------
 
     @action(
         detail=False,

--- a/backend/pawtel/hotel_owners/views.py
+++ b/backend/pawtel/hotel_owners/views.py
@@ -122,7 +122,7 @@ class HotelOwnerViewSet(viewsets.ModelViewSet):
     @action(
         detail=False,
         methods=["get"],
-        url_path="hotel-owners-me",
+        url_path="me",
         url_name="retrieve_current_hotel_owner",
     )
     def retrieve_current_hotel_owner(self, request):

--- a/frontend/src/data-layer/api/hotelOwners.ts
+++ b/frontend/src/data-layer/api/hotelOwners.ts
@@ -76,7 +76,7 @@ export const deleteAllHotelsOfOwner = async (hotelOwnerId: number) => {
 };
 
 export const getCurrentHotelOwner = async () => {
-    const url = `${API_BASE_URL}/hotel-owners/hotel-owners-me`;
+    const url = `${API_BASE_URL}/hotel-owners/me`;
     const response = await axios.get(url);
     return response.data as HotelOwner;
 }


### PR DESCRIPTION
### **User description**
Al final lo de incluir en el body las PK de los usuarios, como en este caso solo tenemos hotel, ya estaba hecho.

Lo otro sí había que hacerlo.

Closes #152


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored hotel owner routes to support implicit and explicit PK handling.

- Added new views and actions for retrieving and deleting hotels.

- Updated tests to cover new implicit and explicit route scenarios.

- Adjusted frontend API calls to align with backend changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Refactored service to support implicit PK handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pawtel/hotel_owners/services.py

<li>Modified <code>authorize_action_hotel_owner</code> to handle optional PKs.<br> <li> Improved logic for retrieving and validating hotel owners.


</details>


  </td>
  <td><a href="https://github.com/LuisMelladoDiaz/Pawtel-ComparadorDeHotelesParaMascotas/pull/153/files#diff-3896f7471e314957ab2f742c15982e1c8009db5729d153a16a8fb890140dbd9a">+13/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Enhanced views with implicit and explicit route handling</code>&nbsp; </dd></summary>
<hr>

backend/pawtel/hotel_owners/views.py

<li>Added implicit and explicit routes for retrieving and deleting hotels.<br> <li> Refactored common logic into private helper methods.<br> <li> Updated route paths and action names for clarity.


</details>


  </td>
  <td><a href="https://github.com/LuisMelladoDiaz/Pawtel-ComparadorDeHotelesParaMascotas/pull/153/files#diff-301c7b9ac2049ef704639d0a6f061545a3a011997776decdddb9d0cc8fe57703">+49/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hotelOwners.ts</strong><dd><code>Adjusted frontend API to match backend changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/data-layer/api/hotelOwners.ts

- Updated API endpoint for retrieving the current hotel owner.


</details>


  </td>
  <td><a href="https://github.com/LuisMelladoDiaz/Pawtel-ComparadorDeHotelesParaMascotas/pull/153/files#diff-0d6b9e62d7d6e661fc60046b63311415cf65634d144eb7b2d45aee40f9b591cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_views.py</strong><dd><code>Updated and added tests for route changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pawtel/hotel_owners/tests/test_views.py

<li>Renamed tests to distinguish implicit and explicit routes.<br> <li> Added new tests for implicit route scenarios.<br> <li> Updated existing tests to align with route changes.


</details>


  </td>
  <td><a href="https://github.com/LuisMelladoDiaz/Pawtel-ComparadorDeHotelesParaMascotas/pull/153/files#diff-372d56089d7ac2e82f2c0de4c1d294f1dfa6484a2bdc48d5bdd9b23f77641578">+22/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>