### PR TITLE
Fix booking_hold 

### DIFF
--- a/backend/pawtel/management/commands/seed_booking_holds.py
+++ b/backend/pawtel/management/commands/seed_booking_holds.py
@@ -2,7 +2,7 @@ import random
 from datetime import date
 
 from django.core.management.base import BaseCommand
-from django.utils.timezone import timedelta
+from django.utils.timezone import now, timedelta
 from faker import Faker
 from pawtel.booking_holds.models import BookingHold
 from pawtel.customers.models import Customer
@@ -72,6 +72,7 @@ class Command(BaseCommand):
                     room_type=room_type,
                     booking_start_date=hold_data["booking_start_date"],
                     booking_end_date=hold_data["booking_end_date"],
+                    hold_expires_at=now() + timedelta(minutes=10),
                 )
                 self.stdout.write(
                     self.style.SUCCESS(
@@ -124,6 +125,7 @@ class Command(BaseCommand):
                     room_type=room_type,
                     booking_start_date=booking_start,
                     booking_end_date=booking_end,
+                    hold_expires_at=now() + timedelta(minutes=10),
                 )
                 self.stdout.write(
                     self.style.SUCCESS(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed missing `hold_expires_at` field in `BookingHold` creation.

- Added `now()` function to calculate expiration time dynamically.

- Ensured deterministic and random booking holds include expiration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seed_booking_holds.py</strong><dd><code>Add `hold_expires_at` to booking holds creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/pawtel/management/commands/seed_booking_holds.py

<li>Added <code>hold_expires_at</code> field to <code>BookingHold</code> creation.<br> <li> Used <code>now()</code> with <code>timedelta</code> to set expiration dynamically.<br> <li> Updated both deterministic and random booking hold creation methods.


</details>


  </td>
  <td><a href="https://github.com/LuisMelladoDiaz/Pawtel-ComparadorDeHotelesParaMascotas/pull/195/files#diff-eb7cad7f44318b7ef85d37b1ce5c9a45dfe0606217c93474210a6a68d6087fbb">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>